### PR TITLE
small icon fix

### DIFF
--- a/android/src/main/java/com/zinspector/foregroundservice/NotificationHelper.java
+++ b/android/src/main/java/com/zinspector/foregroundservice/NotificationHelper.java
@@ -124,7 +124,7 @@ class NotificationHelper {
 
         String iconName = bundle.getString("icon");
         if(iconName == null){
-            iconName = "ic_notification";
+            iconName = "ic_launcher";
         }
         notificationBuilder.setSmallIcon(getResourceIdForResourceName(context, iconName));
 

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ const ForegroundServiceEmitter = ForegroundServiceModule
  * @property {string} title - Notification title
  * @property {string} message - Notification message
  * @property {string} number - int specified as string > 0, for devices that support it, this might be used to set the badge counter
- * @property {string} icon - Small icon name | ic_notification
+ * @property {string} icon - Small icon name | ic_launcher
  * @property {string} largeIcon - Large icon name | ic_launcher
  * @property {string} visibility - private | public | secret
  * @property {boolean} ongoing - true/false if the notification is ongoing. The notification the service was started with will always be ongoing


### PR DESCRIPTION
Fixes: https://github.com/cristianoccazinsp/react-native-foreground-service/issues/16

Newer versions of React/Expo do not leverage `ic_notification` by default. `ic_launcher` can be used as both a small icon and a large icon. Since `NotificationCompat` will not display title or message without a valid small icon, this was causing the issue.